### PR TITLE
Move over_react component into lib

### DIFF
--- a/lib/test_over_react.dart
+++ b/lib/test_over_react.dart
@@ -1,0 +1,45 @@
+import 'package:over_react/over_react.dart';
+
+@Factory()
+UiFactory<FooProps> Foo;
+
+@Props()
+class FooProps extends UiProps {
+  String color;
+}
+
+//@State()
+//class FooState extends UiState {
+//  bool isActive;
+//}
+
+@Component()
+class FooComponent extends UiComponent<FooProps> {
+  @override
+  Map getDefaultProps() =>
+      (newProps()
+        ..color = '#66cc00'
+      );
+
+//  @override
+//  getInitialState() =>
+//      (newState()
+//        ..isActive = false
+//      );
+
+  @override
+  render() {
+    return (Dom.div()
+      ..style = {
+        'color': props.color,
+        'fontWeight': 'normal'
+      }
+    )(
+        (Dom.button()..onClick = _handleButtonClick)('Toggle'),
+        props.children
+    );
+  }
+
+  _handleButtonClick(event) {
+  }
+}

--- a/web/main.dart
+++ b/web/main.dart
@@ -1,53 +1,8 @@
 import 'dart:html';
 
-import 'package:react/react.dart' as react;
-import 'package:react/react_dom.dart' as react_dom;
 import 'package:over_react/over_react.dart';
-
-@Factory()
-UiFactory<FooProps> Foo;
-
-@Props()
-class FooProps extends UiProps {
-  String color;
-}
-
-//@State()
-//class FooState extends UiState {
-//  bool isActive;
-//}
-
-@Component()
-class FooComponent extends UiComponent<FooProps> {
-  @override
-  Map getDefaultProps() =>
-      (newProps()
-        ..color = '#66cc00'
-      );
-
-//  @override
-//  getInitialState() =>
-//      (newState()
-//        ..isActive = false
-//      );
-
-  @override
-  render() {
-    return (Dom.div()
-      ..style = {
-        'color': props.color,
-        'fontWeight': 'normal'
-      }
-    )(
-        (Dom.button()..onClick = _handleButtonClick)('Toggle'),
-        props.children
-    );
-  }
-
-  _handleButtonClick(event) {
-  }
-}
-
+import 'package:react/react_dom.dart' as react_dom;
+import 'package:test3/test_over_react.dart';
 
 void main() {
   setClientConfiguration();


### PR DESCRIPTION
+ The transformer does not run in web/ by default, which is what caused the issue reported via https://github.com/Workiva/over_react/issues/148

Note that in a real application, things like individual components would live somewhere within `lib/src`, and then be optionally exported via a top-level library.  I just put it in a top-level library for simplicity sake.

FYI @francisl 